### PR TITLE
Replace hook_install() with hook_install_tasks()

### DIFF
--- a/draft.install
+++ b/draft.install
@@ -9,21 +9,13 @@ use Drupal\user\Entity\User;
  *
  * Performs tasks to set up the site for the Draft profile.
  *
- * @see install_tasks()
+ * @see hook_install_tasks()
  */
 function draft_install_tasks(&$install_state) {
   return [
     'draft_set_role' => [],
     'draft_config' => [],
   ];
-}
-
-/**
- * Prepares configs for the Draft profile.
- */
-function draft_config(&$install_state) {
-  $config = _draft_read_develop_config_split();
-  _draft_prepare_develop_config_split_directory($config);
 }
 
 /**
@@ -37,6 +29,14 @@ function draft_set_role(&$install_state) {
     $user->addRole($role->id());
     $user->save();
   }
+}
+
+/**
+ * Prepares configs for the Draft profile.
+ */
+function draft_config(&$install_state) {
+  $config = _draft_read_develop_config_split();
+  _draft_prepare_develop_config_split_directory($config);
 }
 
 /**

--- a/draft.install
+++ b/draft.install
@@ -1,19 +1,42 @@
 <?php
 
 use Drupal\Core\Config\FileStorage;
+use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 
 /**
- * Implements hook_install().
+ * Implements hook_install_tasks().
+ *
+ * Performs tasks to set up the site for the Draft profile.
+ *
+ * @see install_tasks()
  */
-function draft_install() {
+function draft_install_tasks(&$install_state) {
+  return [
+    'draft_set_role' => [],
+    'draft_config' => [],
+  ];
+}
+
+/**
+ * Prepares configs for the Draft profile.
+ */
+function draft_config(&$install_state) {
   $config = _draft_read_develop_config_split();
   _draft_prepare_develop_config_split_directory($config);
+}
 
+/**
+ * Sets a role to a user for the Draft profile.
+ */
+function draft_set_role(&$install_state) {
   // Assign user 1 the "administrator" role.
-  $user = User::load(1);
-  $user->roles[] = 'administrator';
-  $user->save();
+  $role = Role::load('administrator');
+  if ($role) {
+    $user = User::load(1);
+    $user->addRole($role->id());
+    $user->save();
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #71 

The draft_install() function from the Draft profile prevents installing from the configuration.